### PR TITLE
Adding OAuth login support (Authorization Code Flow) to an elm Server app

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -13,12 +13,23 @@
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
             "elm/time": "1.0.0",
-            "elm/url": "1.0.0"
+            "elm/url": "1.0.0",
+            "ktonon/elm-jsonwebtoken": "1.0.4",
+            "truqu/elm-base64": "2.0.4"
         },
         "indirect": {
+            "NoRedInk/elm-json-decode-pipeline": "1.0.0",
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
-            "elm/virtual-dom": "1.0.2"
+            "elm/regex": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
+            "elm-community/list-extra": "8.3.1",
+            "elm-community/result-extra": "2.4.0",
+            "ktonon/elm-crypto": "1.1.2",
+            "ktonon/elm-word": "2.1.2",
+            "prozacchiwawa/elm-urlbase64": "1.0.5",
+            "waratuman/elm-coder": "3.0.1",
+            "zwilias/elm-utf-tools": "2.0.1"
         }
     },
     "test-dependencies": {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const jsSha = hash.digest('hex')
 const { Elm } = require('./build/Server.js')
 var app = Elm.Server.init({
   flags: {
+    oauthProviders: JSON.parse(process.env.OAUTH_CONFIG),
     assetsHost: process.env.ASSETS_HOST || '',
     jsSha: jsSha
   }

--- a/src/Webapp/Server/OAuth.elm
+++ b/src/Webapp/Server/OAuth.elm
@@ -1,0 +1,314 @@
+module Webapp.Server.OAuth exposing
+    ( AccessTokenResponse
+    , Config
+    , FreshAccessToken
+    , FreshAccessTokenResponse
+    , GrantType(..)
+    , accessToken
+    , authorizationHeader
+    , authorizeLink
+    , decodeAccessTokenResponse
+    , encodeAccessTokenResponse
+    , freshAccessToken
+    , freshAccessTokenResponse
+    , router
+    , updateFromRoute
+    )
+
+import Base64
+import Http
+import Json.Decode
+import Json.Encode
+import JsonWebToken
+import Task exposing (Task)
+import Time
+import Url.Builder
+import Url.Parser exposing ((</>), (<?>), map, s, string)
+import Url.Parser.Query
+import Webapp.Server.HTTP exposing (Response, StatusCode(..))
+
+
+type alias Config =
+    { authorizeUrl : String
+    , accessTokenUrl : String
+    , clientId : String
+    , clientSecret : String
+    , scopes : String
+    , httpTimeout : Maybe Float
+    , customHeaders : List ( String, String )
+    , customParams : List ( String, String )
+    }
+
+
+updateFromRoute :
+    { state : String
+    , onSuccess : AccessTokenResponse -> Task Response Response
+    , onFail : Http.Error -> Response
+    , now : Time.Posix
+    , redirectUrl : String
+    }
+    -> Config
+    -> Result String (Maybe String)
+    -> Task Response Response
+updateFromRoute { state, onSuccess, onFail, now, redirectUrl } oauthConfig codeResult =
+    case codeResult of
+        Ok Nothing ->
+            let
+                targetUrl =
+                    authorizeLink oauthConfig { state = state, redirectUrl = redirectUrl }
+            in
+            Task.succeed
+                { statusCode = StatusSeeOther
+                , body = "Go to " ++ targetUrl
+                , headers =
+                    [ ( "Location", Json.Encode.string targetUrl )
+                    ]
+                }
+
+        Ok (Just code) ->
+            let
+                withFreshAccessToken tokenResponse =
+                    freshAccessTokenResponse tokenResponse oauthConfig redirectUrl now
+                        |> Task.map freshAccessToken
+            in
+            accessToken oauthConfig redirectUrl [] (GrantAuthorizationCode code)
+                |> Task.mapError onFail
+                |> Task.andThen onSuccess
+
+        Err err ->
+            Task.fail (onFail (Http.BadUrl err))
+
+
+authorizeLink : Config -> { state : String, redirectUrl : String } -> String
+authorizeLink { authorizeUrl, clientId, customParams, scopes } { state, redirectUrl } =
+    authorizeUrl
+        ++ Url.Builder.toQuery
+            ([ Url.Builder.string "client_id" clientId
+             , Url.Builder.string "scope" scopes
+             , Url.Builder.string "redirect_uri" redirectUrl
+             , Url.Builder.string "state" state
+             ]
+                ++ List.map (\( key, value ) -> Url.Builder.string key value) customParams
+            )
+
+
+type AccessToken
+    = AccessToken String
+
+
+decodeAccessToken : Json.Decode.Decoder AccessToken
+decodeAccessToken =
+    Json.Decode.string
+        |> Json.Decode.map AccessToken
+
+
+encodeAccessToken : AccessToken -> Json.Encode.Value
+encodeAccessToken (AccessToken s) =
+    Json.Encode.string s
+
+
+authorizationHeader : FreshAccessToken -> Http.Header
+authorizationHeader (FreshAccessToken s) =
+    Http.header "Authorization" ("Bearer " ++ s)
+
+
+type RefreshToken
+    = RefreshToken String
+
+
+decodeRefreshToken : Json.Decode.Decoder RefreshToken
+decodeRefreshToken =
+    Json.Decode.string
+        |> Json.Decode.map RefreshToken
+
+
+encodeRefreshToken : RefreshToken -> Json.Encode.Value
+encodeRefreshToken (RefreshToken s) =
+    Json.Encode.string s
+
+
+type alias AccessTokenResponse =
+    { accessToken : AccessToken
+    , refreshToken : Maybe RefreshToken
+    , raw : Json.Encode.Value
+    }
+
+
+decodeAccessTokenResponse : Json.Decode.Decoder AccessTokenResponse
+decodeAccessTokenResponse =
+    Json.Decode.map3 AccessTokenResponse
+        (Json.Decode.field "access_token" Json.Decode.string |> Json.Decode.map AccessToken)
+        (Json.Decode.maybe (Json.Decode.field "refresh_token" Json.Decode.string |> Json.Decode.map RefreshToken))
+        Json.Decode.value
+
+
+encodeAccessTokenResponse : AccessTokenResponse -> Json.Encode.Value
+encodeAccessTokenResponse resp =
+    let
+        (AccessToken atoken) =
+            resp.accessToken
+
+        rtoken =
+            case resp.refreshToken of
+                Just (RefreshToken a) ->
+                    [ ( "refreshToken", Json.Encode.string a ) ]
+
+                _ ->
+                    []
+    in
+    Json.Encode.object
+        (( "accessToken", Json.Encode.string atoken ) :: rtoken)
+
+
+type GrantType
+    = GrantAuthorizationCode String
+    | GrantRefreshToken RefreshToken
+
+
+accessToken : Config -> String -> List Url.Builder.QueryParameter -> GrantType -> Task Http.Error AccessTokenResponse
+accessToken { accessTokenUrl, clientId, clientSecret, httpTimeout, customHeaders, customParams } redirectUrl moreParams tokenRequest =
+    let
+        removePrefix prefix s =
+            if String.startsWith prefix s then
+                String.dropLeft (String.length prefix) s
+
+            else
+                s
+
+        codeParams =
+            case tokenRequest of
+                GrantAuthorizationCode code ->
+                    [ Url.Builder.string "code" code
+                    , Url.Builder.string "grant_type" "authorization_code"
+                    ]
+
+                GrantRefreshToken (RefreshToken refreshToken) ->
+                    [ Url.Builder.string "refresh_token" refreshToken
+                    , Url.Builder.string "grant_type" "refresh_token"
+                    ]
+
+        bodyPayload =
+            Url.Builder.toQuery
+                ([ Url.Builder.string "client_id" clientId
+                 , Url.Builder.string "client_secret" clientSecret
+                 , Url.Builder.string "redirect_uri" redirectUrl
+                 ]
+                    ++ List.map (\( key, value ) -> Url.Builder.string key value) customParams
+                    ++ codeParams
+                    ++ moreParams
+                )
+                |> removePrefix "?"
+
+        httpJsonBodyResolver : Json.Decode.Decoder a -> Http.Response String -> Result Http.Error a
+        httpJsonBodyResolver decoder resp =
+            case resp of
+                Http.GoodStatus_ m s ->
+                    Json.Decode.decodeString decoder s
+                        |> Result.mapError (Json.Decode.errorToString >> Http.BadBody)
+
+                Http.BadUrl_ s ->
+                    Err (Http.BadUrl s)
+
+                Http.Timeout_ ->
+                    Err Http.Timeout
+
+                Http.NetworkError_ ->
+                    Err Http.NetworkError
+
+                Http.BadStatus_ m s ->
+                    Err (Http.BadStatus m.statusCode)
+    in
+    Http.task
+        { method = "POST"
+        , headers = List.map (\( k, v ) -> Http.header k v) customHeaders
+        , url = accessTokenUrl
+        , body = Http.stringBody "application/x-www-form-urlencoded" bodyPayload
+        , resolver = Http.stringResolver (httpJsonBodyResolver decodeAccessTokenResponse)
+        , timeout = httpTimeout
+        }
+
+
+{-| no verification here. just decoding the data.
+useful for extracting `exp` to know if token had expired
+
+extracted from JsonWebToken `decodePayload`
+
+-}
+decodePayloadWithoutVerification : Json.Decode.Decoder a -> AccessToken -> Result String a
+decodePayloadWithoutVerification decoder (AccessToken string) =
+    case String.split "." string of
+        [ part0, part1, signVar ] ->
+            part1
+                |> Base64.decode
+                |> Result.andThen (Json.Decode.decodeString decoder >> Result.mapError Json.Decode.errorToString)
+
+        _ ->
+            Err "Invalid token"
+
+
+expiry : AccessToken -> Maybe Time.Posix
+expiry token =
+    let
+        decoder =
+            Json.Decode.field "exp" Json.Decode.int |> Json.Decode.map (\i -> Time.millisToPosix (i * 1000))
+    in
+    decodePayloadWithoutVerification decoder token
+        |> Result.toMaybe
+
+
+{-| Returns a wrapped `FreshAccessTokenResponse oauth` if already fresh, otherwise obtain a fresh one
+-}
+freshAccessTokenResponse : AccessTokenResponse -> Config -> String -> Time.Posix -> Task Http.Error FreshAccessTokenResponse
+freshAccessTokenResponse oauth config redirectUrl now =
+    let
+        accessTokenExpiry =
+            Maybe.withDefault now (expiry oauth.accessToken) |> Time.posixToMillis
+    in
+    case ( oauth.refreshToken, accessTokenExpiry > (Time.posixToMillis now + (600 * 1000)) ) of
+        ( Just refreshToken, False ) ->
+            accessToken config redirectUrl [] (GrantRefreshToken refreshToken)
+                |> Task.map FreshAccessTokenResponse
+
+        ( _, True ) ->
+            Task.succeed (FreshAccessTokenResponse oauth)
+
+        ( Nothing, False ) ->
+            -- best effort attempt with existing access token
+            Task.succeed (FreshAccessTokenResponse oauth)
+
+
+type FreshAccessTokenResponse
+    = FreshAccessTokenResponse AccessTokenResponse
+
+
+{-| only obtained via freshAccessToken
+-}
+type FreshAccessToken
+    = FreshAccessToken String
+
+
+freshAccessToken : FreshAccessTokenResponse -> FreshAccessToken
+freshAccessToken (FreshAccessTokenResponse resp) =
+    let
+        (AccessToken s) =
+            resp.accessToken
+    in
+    FreshAccessToken s
+
+
+
+-- Route
+
+
+router : Url.Parser.Parser (a -> Maybe error -> value -> d) (String -> Maybe String -> Maybe String -> b) -> (a -> Result error value -> d) -> Url.Parser.Parser (b -> c) c
+router prefix constructor =
+    let
+        fn provider maybeErr maybeCode =
+            case maybeErr of
+                Just x ->
+                    constructor provider (Err x)
+
+                Nothing ->
+                    constructor provider (Ok maybeCode)
+    in
+    map fn (prefix </> Url.Parser.string <?> Url.Parser.Query.string "error" <?> Url.Parser.Query.string "code")


### PR DESCRIPTION
Start with an app created from https://package.elm-lang.org/packages/choonkeat/elm-webapp/latest

1. Setup `OAUTH_CONFIG` environment variable, which is a list of configs.

    Here's an example that integrates with Azure, Github, and Slack via OAuth:

    ```
    export OAUTH_CONFIG='
        [ [ "azure"
          , { "authorizeUrl": "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize"
            , "accessTokenUrl": "https://login.microsoftonline.com/organizations/oauth2/v2.0/token"
            , "clientSecret": "<REPLACE ME>"
            , "clientId": "<REPLACE ME>"
            , "scopes": "User.Read"
            , "customHeaders":
                []
            , "customParams":
                [ ["tenant", "<REPLACE ME>" ]
                , ["response_type", "code"]
                , ["response_mode", "query"]
                ]
            , "httpTimeout": 30000
            }
          ]
        , [ "github"
          , { "authorizeUrl": "https://github.com/login/oauth/authorize"
            , "accessTokenUrl": "https://github.com/login/oauth/access_token"
            , "clientSecret": "<REPLACE ME>"
            , "clientId": "<REPLACE ME>"
            , "scopes": "read:user"
            , "customHeaders":
                [ [ "Accept", "application/json" ]
                ]
            , "customParams":
                []
            , "httpTimeout": 30000
            }
          ]
        , [ "slack"
          , { "authorizeUrl": "https://slack.com/oauth/authorize"
            , "accessTokenUrl": "https://slack.com/api/oauth.access"
            , "clientSecret": "<REPLACE ME>"
            , "clientId": "<REPLACE ME>"
            , "scopes": "users:read"
            , "customHeaders":
                []
            , "customParams":
                []
            , "httpTimeout": 30000
            }
          ]
        ]'
    ```

    NOTE: change all the `<REPLACE ME>` values

2. Boot up the elm-webapp server like usual

    ```
    $ make
    Compiled in DEV mode. Follow the advice at https://elm-lang.org/0.19.1/optimize for better performance and smaller assets.
    [ 'js' ] httpServer [Function: nodeHttpServer]
    [ 'js' ] [ 'http' ] nodeHttpServer
    [ 'js' ] [ 'http' ] server listening at 8000 ...
    ```

3. Now you can visit `/oauth/<provider>` url to login with the desired provider

    - http://localhost:8000/oauth/azure
    - http://localhost:8000/oauth/github
    - http://localhost:8000/oauth/slack

This is the integration approach for regular server side webapps, aka [Authorization Code Flow](https://auth0.com/docs/flows/authorization-code-flow)